### PR TITLE
Support for typed throws, and remove `throws` from non-throwing function bodies

### DIFF
--- a/Sources/BP7/Bundle.swift
+++ b/Sources/BP7/Bundle.swift
@@ -68,7 +68,7 @@ public struct Bundle: Equatable, Sendable {
     }
     
     /// Convert the bundle to CBOR format
-    public func encode() throws -> [UInt8] {
+    public func encode() -> [UInt8] {
         var items: [CBOR] = []
         
         // Add primary block
@@ -85,7 +85,7 @@ public struct Bundle: Equatable, Sendable {
     }
     
     /// Decode a bundle from CBOR format
-    public static func decode(from data: [UInt8]) throws -> Bundle {
+    public static func decode(from data: [UInt8]) throws(BP7Error) -> Bundle {
         guard let cbor = try? CBOR.decode(data),
               case .array(let items) = cbor,
               !items.isEmpty else {
@@ -107,7 +107,7 @@ public struct Bundle: Equatable, Sendable {
             }
             
             // Create a primary block from the CBOR data
-            let builder = PrimaryBlockBuilder()
+            let builder = try PrimaryBlockBuilder.from(primaryCbor)
             // We need to extract and set all the fields from the CBOR data
             // For now, we'll use a simplified approach
             primary = try builder.build()
@@ -132,7 +132,7 @@ public struct Bundle: Equatable, Sendable {
     }
     
     /// Validate the bundle
-    public func validate() throws {
+    public func validate() throws(BP7Error) {
         // Validate primary block
         try primary.validate()
         

--- a/Sources/BP7/EndpointID.swift
+++ b/Sources/BP7/EndpointID.swift
@@ -74,7 +74,7 @@ public enum EndpointID: Hashable, Equatable, Sendable, CustomStringConvertible {
     /// - Parameter uri: The URI string.
     /// - Returns: A new endpoint ID.
     /// - Throws: An error if the URI is invalid.
-    public static func from(_ uri: String) throws -> EndpointID {
+    public static func from(_ uri: String) throws(BP7Error) -> EndpointID {
         // Split the URI into scheme and SSP
         let parts = uri.split(separator: ":", maxSplits: 1)
         guard parts.count == 2 else {
@@ -98,7 +98,7 @@ public enum EndpointID: Hashable, Equatable, Sendable, CustomStringConvertible {
     /// - Parameter ssp: The SSP string.
     /// - Returns: A new DTN endpoint ID.
     /// - Throws: An error if the SSP is invalid.
-    private static func fromDTN(_ ssp: String) throws -> EndpointID {
+    private static func fromDTN(_ ssp: String) -> EndpointID {
         if ssp == "none" {
             return .none()
         }
@@ -129,7 +129,7 @@ public enum EndpointID: Hashable, Equatable, Sendable, CustomStringConvertible {
     /// - Parameter ssp: The SSP string.
     /// - Returns: A new IPN endpoint ID.
     /// - Throws: An error if the SSP is invalid.
-    private static func fromIPN(_ ssp: String) throws -> EndpointID {
+    private static func fromIPN(_ ssp: String) throws(BP7Error) -> EndpointID {
         // Split the SSP into node and service numbers
         let parts = ssp.split(separator: ".", maxSplits: 1)
         guard parts.count == 2 else {
@@ -232,7 +232,7 @@ public enum EndpointID: Hashable, Equatable, Sendable, CustomStringConvertible {
 
 // MARK: - CBOR Coding
 extension EndpointID {
-    public func encode() throws -> CBOR {
+    public func encode() -> CBOR {
         switch self {
         case .dtn(let eidType, let name):
             return .array([.unsignedInt(UInt64(eidType)), .textString(name.description)])
@@ -250,7 +250,7 @@ extension EndpointID {
         }
     }
     
-    public init(from cbor: CBOR) throws {
+    public init(from cbor: CBOR) throws(BP7Error) {
         guard case let .array(items) = cbor, items.count == 2 else {
             throw BP7Error.invalidBlock
         }

--- a/Tests/BP7Tests/AdministrativeRecordTests.swift
+++ b/Tests/BP7Tests/AdministrativeRecordTests.swift
@@ -63,27 +63,23 @@ struct AdministrativeRecordTests {
         #expect(report.timestamp == timestamp)
         
         // Test CBOR encoding
+        let cbor = report.encode()
+        // Check that CBOR encoding was successful
+        #expect(Bool(true))
+        
+        // Test decoding
         do {
-            let cbor = try report.encode()
-            // Check that CBOR encoding was successful
-            #expect(Bool(true))
-            
-            // Test decoding
-            do {
-                let decoded = try StatusReport.decode(from: cbor)
-                #expect(decoded.statusInformation.count == 4)
-                #expect(decoded.statusInformation[0].asserted == report.statusInformation[0].asserted)
-                #expect(decoded.statusInformation[1].asserted == report.statusInformation[1].asserted)
-                #expect(decoded.statusInformation[2].asserted == report.statusInformation[2].asserted)
-                #expect(decoded.statusInformation[3].asserted == report.statusInformation[3].asserted)
-                #expect(decoded.reportReason == report.reportReason)
-                #expect(decoded.sourceNode == report.sourceNode)
-                #expect(decoded.timestamp == report.timestamp)
-            } catch {
-                #expect(Bool(false), "Decoding should not throw: \(error)")
-            }
+            let decoded = try StatusReport.decode(from: cbor)
+            #expect(decoded.statusInformation.count == 4)
+            #expect(decoded.statusInformation[0].asserted == report.statusInformation[0].asserted)
+            #expect(decoded.statusInformation[1].asserted == report.statusInformation[1].asserted)
+            #expect(decoded.statusInformation[2].asserted == report.statusInformation[2].asserted)
+            #expect(decoded.statusInformation[3].asserted == report.statusInformation[3].asserted)
+            #expect(decoded.reportReason == report.reportReason)
+            #expect(decoded.sourceNode == report.sourceNode)
+            #expect(decoded.timestamp == report.timestamp)
         } catch {
-            #expect(Bool(false), "Encoding should not throw: \(error)")
+            #expect(Bool(false), "Decoding should not throw: \(error)")
         }
     }
     
@@ -121,29 +117,24 @@ struct AdministrativeRecordTests {
         }
         
         // Test CBOR encoding
+        let cbor = record.encode()
+        // Check that CBOR encoding was successful
+        #expect(Bool(true))
+        
+        // Test decoding
         do {
-            let cbor = try record.encode()
-            // Check that CBOR encoding was successful
-            #expect(Bool(true))
-            
-            // Test decoding
-            do {
-                let decoded = try AdministrativeRecord.decode(from: cbor)
-                if case .bundleStatusReport(let statusReport) = decoded {
-                    #expect(statusReport.statusInformation.count == 4)
-                    #expect(statusReport.reportReason == report.reportReason)
-                    #expect(statusReport.sourceNode == report.sourceNode)
-                    #expect(statusReport.timestamp == report.timestamp)
-                } else {
-                    #expect(Bool(false), "Expected status report")
-                }
-            } catch {
-                #expect(Bool(false), "Decoding should not throw: \(error)")
+            let decoded = try AdministrativeRecord.decode(from: cbor)
+            if case .bundleStatusReport(let statusReport) = decoded {
+                #expect(statusReport.statusInformation.count == 4)
+                #expect(statusReport.reportReason == report.reportReason)
+                #expect(statusReport.sourceNode == report.sourceNode)
+                #expect(statusReport.timestamp == report.timestamp)
+            } else {
+                #expect(Bool(false), "Expected status report")
             }
         } catch {
-            #expect(Bool(false), "Encoding should not throw: \(error)")
+            #expect(Bool(false), "Decoding should not throw: \(error)")
         }
-        
         // Test to canonical block
         let block = record.toPayload()
         #expect(block.blockType == BlockType.payload.rawValue)


### PR DESCRIPTION
This also simplifies the tests a fair bit